### PR TITLE
[FIX] 상태메시지가 사라지던 오류 수정 외 1

### DIFF
--- a/src/main/java/site/lets_onion/lets_onionApp/controller/MemberController.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/controller/MemberController.java
@@ -10,6 +10,7 @@ import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import jakarta.annotation.Nullable;
 import jakarta.servlet.http.HttpServletRequest;
 import java.net.URI;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
@@ -21,7 +22,6 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
-import site.lets_onion.lets_onionApp.dto.integration.KakaoFriendRequestDTO;
 import site.lets_onion.lets_onionApp.dto.integration.KakaoScopesDTO;
 import site.lets_onion.lets_onionApp.dto.jwt.LogoutDTO;
 import site.lets_onion.lets_onionApp.dto.jwt.RefreshTokenDTO;
@@ -231,7 +231,7 @@ public class MemberController {
     자세한 내용은
     https://developers.kakao.com/docs/latest/ko/kakaotalk-social/rest-api#get-friends
     """)
-    public ResponseDTO<KakaoFriendRequestDTO> requestKakaoFriends(
+    public ResponseDTO<List<MemberInfoDTO>> requestKakaoFriends(
             HttpServletRequest request,
             @RequestParam int offset
     ) {

--- a/src/main/java/site/lets_onion/lets_onionApp/dto/integration/FriendFromKakao.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/dto/integration/FriendFromKakao.java
@@ -1,0 +1,15 @@
+package site.lets_onion.lets_onionApp.dto.integration;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Data;
+
+@Data
+public class FriendFromKakao {
+
+  private Long id;
+  private String uuid;
+  @JsonProperty("profile_nickname")
+  private String profileNickname;
+  @JsonProperty("profile_thumbnail_image")
+  private String profileImage;
+}

--- a/src/main/java/site/lets_onion/lets_onionApp/dto/integration/KakaoFriendRequestDTO.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/dto/integration/KakaoFriendRequestDTO.java
@@ -1,26 +1,13 @@
 package site.lets_onion.lets_onionApp.dto.integration;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.Data;
-
 import java.util.List;
+import lombok.Data;
 
 @Data
 public class KakaoFriendRequestDTO {
     @JsonProperty("total_count")
     private int totalCount;
-    @JsonProperty("Friend")
-    private List<Friend> friends;
-
-
-    @Data
-    static public class Friend {
-
-        private Long id;
-        private String uuid;
-        @JsonProperty("profile_nickname")
-        private String profileNickname;
-        @JsonProperty("profile_thumbnail_image")
-        private String profileImage;
-    }
+    @JsonProperty("elements")
+    private List<FriendFromKakao> friends;
 }

--- a/src/main/java/site/lets_onion/lets_onionApp/repository/member/BaseMemberRepository.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/repository/member/BaseMemberRepository.java
@@ -1,5 +1,6 @@
 package site.lets_onion.lets_onionApp.repository.member;
 
+import java.util.List;
 import java.util.Optional;
 import site.lets_onion.lets_onionApp.domain.member.Member;
 
@@ -10,6 +11,12 @@ public interface BaseMemberRepository {
 
   /*로그인 시 카카오 ID로 조회*/
   Optional<Member> findByKakaoId(Long kakaoId);
+
+  /*카카오 ID 배열로 모두 조회*/
+  List<Member> findAllByKakaoId(Long memberId, List<Long> kakaoIds);
+
+  /*자신과 친구가 아닌 유저들만 조회*/
+  List<Member> findAllNotFriend(Long memberId, List<Long> memberIds);
 
   /*닉네임으로 조회*/
   Member findByNickname(String nickname);

--- a/src/main/java/site/lets_onion/lets_onionApp/repository/member/BaseMemberRepositoryImpl.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/repository/member/BaseMemberRepositoryImpl.java
@@ -3,8 +3,10 @@ package site.lets_onion.lets_onionApp.repository.member;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.NoResultException;
 import jakarta.persistence.PersistenceContext;
+import java.util.List;
 import java.util.Optional;
 import org.springframework.stereotype.Repository;
+import site.lets_onion.lets_onionApp.domain.friendship.FriendshipStatus;
 import site.lets_onion.lets_onionApp.domain.member.Member;
 import site.lets_onion.lets_onionApp.util.exception.CustomException;
 import site.lets_onion.lets_onionApp.util.exception.Exceptions;
@@ -12,45 +14,69 @@ import site.lets_onion.lets_onionApp.util.exception.Exceptions;
 @Repository
 public class BaseMemberRepositoryImpl implements BaseMemberRepository {
 
-    @PersistenceContext
-    private EntityManager em;
+  @PersistenceContext
+  private EntityManager em;
 
-    @Override
-    public Member findByMemberId(Long memberId) {
-        return Optional.ofNullable(em.find(
-                Member.class, memberId
-            )
-        ).orElseThrow(() ->
-            new CustomException(Exceptions.MEMBER_NOT_EXIST));
+  @Override
+  public Member findByMemberId(Long memberId) {
+    return Optional.ofNullable(em.find(
+            Member.class, memberId
+        )
+    ).orElseThrow(() ->
+        new CustomException(Exceptions.MEMBER_NOT_EXIST));
+  }
+
+
+  @Override
+  public Optional<Member> findByKakaoId(Long kakaoId) {
+    try {
+      return Optional.ofNullable(em.createQuery("select m from Member m"
+              + " where m.kakaoId =:kakaoId", Member.class)
+          .setParameter("kakaoId", kakaoId)
+          .getSingleResult());
+    } catch (NoResultException e) {
+      return Optional.empty();
     }
+  }
+
+  @Override
+  public List<Member> findAllByKakaoId(Long memberId, List<Long> kakaoIds) {
+    return em.createQuery("select m from Member m"
+            + " where m.kakaoId in :kakaoIds", Member.class)
+        .setParameter("kakaoIds", kakaoIds)
+        .getResultList();
+  }
+
+  @Override
+  public List<Member> findAllNotFriend(Long memberId, List<Long> memberIds) {
+    return em.createQuery("select m from Member m"
+        + " left join Friendship f on"
+        + " (m.id = f.toMember.id or m.id = f.toMember.id)"
+        + " and (f.fromMember.id =:memberId or f.toMember.id =:memberId)"
+        + " and f.status !=:REJECT"
+        + " where m.id in :memberIds"
+        + " and (f.id is null or f.status =:REJECT)", Member.class)
+        .setParameter("memberId", memberId)
+        .setParameter("memberIds", memberIds)
+        .setParameter("REJECT", FriendshipStatus.REJECT)
+        .getResultList();
+  }
 
 
-    @Override
-    public Optional<Member> findByKakaoId(Long kakaoId) {
-        try {
-            return Optional.ofNullable(em.createQuery("select m from Member m"
-                + " where m.kakaoId =:kakaoId", Member.class)
-                .setParameter("kakaoId", kakaoId)
-                .getSingleResult());
-        } catch (NoResultException e) {
-            return Optional.empty();
-        }
-    }
+  @Override
+  public Member findByNickname(String nickname) {
+    return em.createQuery("select m from Member m " +
+            " where m.nickname =:nickname", Member.class)
+        .setParameter("nickname", nickname)
+        .getSingleResult();
+  }
 
-    @Override
-    public Member findByNickname(String nickname) {
-        return em.createQuery("select m from Member m " +
-                        " where m.nickname =:nickname", Member.class)
-                .setParameter("nickname", nickname)
-                .getSingleResult();
-    }
-
-    @Override
-    public Member findWithDeviceTokens(Long memberId) {
-        return em.createQuery("select m from Member m" +
-                " left join fetch m.deviceTokens" +
-                " where m.id =:memberId", Member.class)
-                .setParameter("memberId", memberId)
-                .getSingleResult();
-    }
+  @Override
+  public Member findWithDeviceTokens(Long memberId) {
+    return em.createQuery("select m from Member m" +
+            " left join fetch m.deviceTokens" +
+            " where m.id =:memberId", Member.class)
+        .setParameter("memberId", memberId)
+        .getSingleResult();
+  }
 }

--- a/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberService.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberService.java
@@ -1,10 +1,15 @@
 package site.lets_onion.lets_onionApp.service.member;
 
-import site.lets_onion.lets_onionApp.dto.integration.KakaoFriendRequestDTO;
+import java.util.List;
 import site.lets_onion.lets_onionApp.dto.integration.KakaoScopesDTO;
 import site.lets_onion.lets_onionApp.dto.jwt.LogoutDTO;
 import site.lets_onion.lets_onionApp.dto.jwt.TokenDTO;
-import site.lets_onion.lets_onionApp.dto.member.*;
+import site.lets_onion.lets_onionApp.dto.member.AppLoginDTO;
+import site.lets_onion.lets_onionApp.dto.member.LoginDTO;
+import site.lets_onion.lets_onionApp.dto.member.MemberInfoDTO;
+import site.lets_onion.lets_onionApp.dto.member.MypageMemberInfoRequestDTO;
+import site.lets_onion.lets_onionApp.dto.member.MypageMemberInfoResponseDTO;
+import site.lets_onion.lets_onionApp.dto.member.StatusMessageDTO;
 import site.lets_onion.lets_onionApp.dto.onion.GainedOnionDTO;
 import site.lets_onion.lets_onionApp.dto.push.PushNotificationDTO;
 import site.lets_onion.lets_onionApp.util.push.PushType;
@@ -49,7 +54,7 @@ public interface MemberService {
     ResponseDTO<KakaoScopesDTO> checkKakaoScopes(Long memberId);
 
     /*유저의 카카오 친구 목록 조회*/
-    ResponseDTO<KakaoFriendRequestDTO> requestKakaoFriends(Long memberId, int offset);
+    ResponseDTO<List<MemberInfoDTO>> requestKakaoFriends(Long memberId, int offset);
 
     // 마이페이지에서 유저 정보 조회
     ResponseDTO<MypageMemberInfoResponseDTO> getMypageMemberInfo(Long memberId);

--- a/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberServiceImpl.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberServiceImpl.java
@@ -171,7 +171,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   @Transactional
   public ResponseDTO<StatusMessageDTO> updateStatusMessage(Long memberId, String message) {
-    serviceRedisConnector.setWithTtl(memberId.toString(), message, 86400000L); // 24시간 유지
+    serviceRedisConnector.setWithTtl(memberId.toString()+"_status_message", message, 86400000L); // 24시간 유지
     return new ResponseDTO<>(new StatusMessageDTO(message),
         Responses.CREATED);
   }
@@ -186,7 +186,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   @Transactional
   public ResponseDTO<StatusMessageDTO> getStatusMessage(Long memberId) {
-    String message = serviceRedisConnector.get(memberId.toString());
+    String message = serviceRedisConnector.get(memberId.toString()+"_status_message");
     return new ResponseDTO<>(new StatusMessageDTO(message),
         Responses.OK);
   }


### PR DESCRIPTION
### 이슈 번호
- 
### 작업한 내용
- 상태메시지가 Redis DB에서 사라지던 오류 수정
- 카카오 친구 리스트를 조회할 때 서버 내 Member 엔티티로 조회하도록 수정