### PR TITLE
[REFACTOR] 상태메시지 메소드 분리 및 유저 기본 프로필 이미지 설정

### DIFF
--- a/src/main/java/site/lets_onion/lets_onionApp/domain/member/Member.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/domain/member/Member.java
@@ -1,13 +1,24 @@
 package site.lets_onion.lets_onionApp.domain.member;
 
-import jakarta.persistence.*;
-import lombok.*;
-
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Embedded;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OneToOne;
 import java.util.ArrayList;
 import java.util.List;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.NonNull;
 import site.lets_onion.lets_onionApp.domain.DeviceToken;
 import site.lets_onion.lets_onionApp.domain.onion.GrowingOnion;
-import site.lets_onion.lets_onionApp.domain.onion.OnionLevel;
 import site.lets_onion.lets_onionApp.domain.onionBook.OnionBook;
 
 @Entity @Getter
@@ -43,7 +54,7 @@ public class Member {
         pushNotification = new PushNotification();
         this.onions = GrowingOnion.builder().member(this).build();
         this.onionBook = OnionBook.builder().member(this).build();
-        this.userImageUrl = OnionLevel.ZERO.getPosImageUrl();
+        this.userImageUrl = "https://imgur.com/dNv03Iq.png"; // 기본 프로필 이미지를 깐양파로 설정
     }
 
     public void updateNickname(String nickname) {

--- a/src/main/java/site/lets_onion/lets_onionApp/domain/onionBook/OnionType.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/domain/onionBook/OnionType.java
@@ -12,7 +12,6 @@ public enum OnionType {
     ONION_GGANG("양파깡", "https://imgur.com/s8D57zC.png"),
     ONION_RING("양파링", "https://imgur.com/vfcZzfs.png"),
     ONION_RAW("생양파", "https://imgur.com/cpH5jvA.png"),
-    ONION_PILLED("깐양파", "https://imgur.com/dNv03Iq.png"),
     ONION_FRIED("양파튀김", "https://imgur.com/NNg1jfT.png"),
     ONION_PICKLE("양파피클", "https://imgur.com/4mjrwWX.png"),
     ONION_SUSHI("양파가 누운 연어초밥", "https://imgur.com/rHv8v3c.png"),

--- a/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberServiceImpl.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberServiceImpl.java
@@ -171,7 +171,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   @Transactional
   public ResponseDTO<StatusMessageDTO> updateStatusMessage(Long memberId, String message) {
-    serviceRedisConnector.setWithTtl(memberId.toString()+"_status_message", message, 86400000L); // 24시간 유지
+    serviceRedisConnector.setStatusMessage(memberId.toString(), message); // 24시간 유지
     return new ResponseDTO<>(new StatusMessageDTO(message),
         Responses.CREATED);
   }
@@ -186,7 +186,7 @@ public class MemberServiceImpl implements MemberService {
   @Override
   @Transactional
   public ResponseDTO<StatusMessageDTO> getStatusMessage(Long memberId) {
-    String message = serviceRedisConnector.get(memberId.toString()+"_status_message");
+    String message = serviceRedisConnector.getStatusMessage(memberId.toString());
     return new ResponseDTO<>(new StatusMessageDTO(message),
         Responses.OK);
   }

--- a/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberServiceImpl.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/service/member/MemberServiceImpl.java
@@ -10,7 +10,6 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import site.lets_onion.lets_onionApp.domain.DeviceToken;
 import site.lets_onion.lets_onionApp.domain.member.Member;
-import site.lets_onion.lets_onionApp.domain.onion.OnionLevel;
 import site.lets_onion.lets_onionApp.domain.onionBook.CollectedOnion;
 import site.lets_onion.lets_onionApp.domain.onionBook.OnionBook;
 import site.lets_onion.lets_onionApp.domain.onionBook.OnionType;
@@ -404,8 +403,7 @@ public class MemberServiceImpl implements MemberService {
     // 1개 이상 모인 양파 리스트
     List<OnionImageUrlDTO> onionImageUrlDTOS = new ArrayList<>();
     // 아직 도감에서 모은 양파가 없을 경우를 대비해 디폴트 프로필 이미지로 긍정/부정양파 0단계 제공
-    onionImageUrlDTOS.add(new OnionImageUrlDTO(OnionLevel.ZERO.getPosImageUrl()));
-    onionImageUrlDTOS.add(new OnionImageUrlDTO(OnionLevel.ZERO.getNegImageUrl()));
+    onionImageUrlDTOS.add(new OnionImageUrlDTO("https://imgur.com/dNv03Iq.png"));
     for (OnionType onionType: OnionType.values()) {
       CollectedOnion collectedOnion = onionBook.getOnion(onionType);
       if (collectedOnion.getCollectedQuantity() == 0) {

--- a/src/main/java/site/lets_onion/lets_onionApp/service/onionBook/OnionBookServiceImpl.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/service/onionBook/OnionBookServiceImpl.java
@@ -49,7 +49,7 @@ public class OnionBookServiceImpl implements OnionBookService{
 
         String message = "";
         try {
-            message = serviceRedisConnector.get(memberId.toString());
+            message = serviceRedisConnector.getStatusMessage(memberId.toString());
         } catch (Exception e) {
             message = "";
         }

--- a/src/main/java/site/lets_onion/lets_onionApp/util/redis/ServiceRedisConnector.java
+++ b/src/main/java/site/lets_onion/lets_onionApp/util/redis/ServiceRedisConnector.java
@@ -23,10 +23,20 @@ public class ServiceRedisConnector {
         redisTemplate.opsForValue().set(key, value, ttl, TimeUnit.MILLISECONDS);
     }
 
+    /*상태 메시지 저장*/
+    public void setStatusMessage(String key, String value) {
+        redisTemplate.opsForValue().set(key+"_status_message", value, 86400000L, TimeUnit.MILLISECONDS);
+    }
+
 
     /*키로 값 조회*/
     public String get(String key){
         return redisTemplate.opsForValue().get(key);
+    }
+
+    /*상태 메시지 조회*/
+    public String getStatusMessage(String key) {
+        return redisTemplate.opsForValue().get(key+"_status_message");
     }
 
 


### PR DESCRIPTION
### 이슈 번호
- 
### 작업한 내용
- 상태 메시지와 토큰을 관리하는 redis 메소드 분리
- 유저 기본 프로필 이미지를 깐양파로 설정